### PR TITLE
Consistent style, docs, classifiers

### DIFF
--- a/evalidate/__init__.py
+++ b/evalidate/__init__.py
@@ -4,6 +4,8 @@
 
 import ast
 
+__version__ = '1.0.2'
+
 
 class EvalException(Exception):
     pass
@@ -135,6 +137,11 @@ def safeeval(expression, context={}, safenodes=None, addnodes=None, funcs=None, 
 
     Returns:
         Any: the result of the expression
+
+    Raises:
+        ExecutionException - if the expression fails to execute
+        CompilationException - if the expression fails to parse
+        ValidationException - if the expression fails safety checks
 
     Example:
         >>> import evalidate

--- a/evalidate/__init__.py
+++ b/evalidate/__init__.py
@@ -3,20 +3,22 @@
 """Safe user-supplied python expression evaluation."""
 
 import ast
-import sys
 
 
 class EvalException(Exception):
     pass
 
+
 class ValidationException(EvalException):
     pass
+
 
 class CompilationException(EvalException):
     exc = None
     def __init__(self, exc):
         super().__init__(exc)
         self.exc = exc
+
 
 class ExecutionException(EvalException):
     exc = None
@@ -50,8 +52,8 @@ class SafeAST(ast.NodeVisitor):
             subscript = ['Subscript', 'Index']  # person['name']
             boolop = ['BoolOp', 'And', 'Or', 'UnaryOp', 'Not']  # True and True
             inop = ["In", "NotIn"]  # "aaa" in i['list']
-            ifop = ["IfExp"] # for if expressions, like: expr1 if expr2 else expr3
-            nameconst = ["NameConstant"] # for True and False constants
+            ifop = ["IfExp"]  # for if expressions, like: expr1 if expr2 else expr3
+            nameconst = ["NameConstant"]  # for True and False constants
             div = ["Div", "Mod"]
 
             self.allowed = expression + constant + values + compare + \
@@ -66,28 +68,27 @@ class SafeAST(ast.NodeVisitor):
 
     def generic_visit(self, node):
         """Check node, raise exception if node is not in whitelist."""
-        
+
         if type(node).__name__ in self.allowed:
 
             if isinstance(node, ast.Attribute):
                 if node.attr not in self.allowed_attrs:
                     raise ValidationException(
                         "Attribute {aname} is not allowed".format(
-                            aname=node.attr))    
-                        
+                            aname=node.attr))
 
             if isinstance(node, ast.Call):
                 if isinstance(node.func, ast.Name):
                     if node.func.id not in self.allowed_funcs:
                         raise ValidationException(
                             "Call to function {fname}() is not allowed".format(
-                                fname=node.func.id))    
+                                fname=node.func.id))
                     else:
                         # Call to allowed function. good. No exception
-                        pass            
+                        pass
                 elif isinstance(node.func, ast.Attribute):
                     pass
-                    # print("attr:", node.func.attr)                                        
+                    # print("attr:", node.func.attr)
                 else:
                     raise ValidationException('Indirect function call')
 
@@ -109,14 +110,47 @@ def evalidate(expression, safenodes=None, addnodes=None, funcs=None, attrs=None)
     except SyntaxError as e:
         raise CompilationException(e)
 
-
     v = SafeAST(safenodes, addnodes, funcs, attrs)
     v.visit(node)
     return node
 
 
 def safeeval(expression, context={}, safenodes=None, addnodes=None, funcs=None, attrs=None):
-    """C-style simplified wrapper, eval() replacement."""
+    """C-style simplified wrapper, eval() replacement.
+
+    Args:
+        expr (str): the expression to evaluate
+
+        safenodes (List[str] | None):
+            Specify the name of allowed AST nodes, if unspecified a default list is used.
+
+        addnodes (List[str] | None):
+            List of additional AST node names to allow in addition to safenodes.
+
+        funcs (List[str]):
+            list of allowed function names.
+
+        attrs (List[str]):
+            list of allowed attribute names.
+
+    Returns:
+        Any: the result of the expression
+
+    Example:
+        >>> import evalidate
+        >>> evalidate.safeeval('3 + 2')
+        5
+        >>> evalidate.safeeval('max(3, 2)')
+        Traceback (most recent call last):
+            ...
+        evalidate.ValidationException: Operation type Call is not allowed
+        >>> evalidate.safeeval('max(3, 2)', addnodes=['Call'])
+        Traceback (most recent call last):
+            ...
+        evalidate.ValidationException: Call to function max() is not allowed
+        >>> evalidate.safeeval('max(3, 2)', addnodes=['Call'], funcs=['max'])
+        3
+    """
 
     # ValidationException thrown here
     node = evalidate(expression, safenodes, addnodes, funcs, attrs)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup
 import os
 
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
 
@@ -11,8 +12,15 @@ setup(name='evalidate',
       author_email='xenon@sysattack.com',
       license='MIT',
       packages=['evalidate'],
-      description = 'Validation and secure evaluation of untrusted python expressions',
-      long_description = read('README.md'),
+      description='Validation and secure evaluation of untrusted python expressions',
+      long_description=read('README.md'),
       long_description_content_type='text/markdown',
+      classifiers=[
+          "Programming Language :: Python :: 3",
+          "License :: OSI Approved :: MIT License",
+          "Operating System :: OS Independent",
+          'Topic :: Utilities',
+          "Topic :: Security",
+          "Topic :: Software Development :: Interpreters",
+      ],
       zip_safe=False)
-


### PR DESCRIPTION
This library looks neat, and similar to something I'm doing as well. This first PR is just some minor cleanup to remove an unused import, make some of the style more consistent, adding some extra metadata to setup.py, and expanding the docstring for `safeeval` (also adding a doctest, which can become part of the test suite if you `pip install xdoctest` and run `pytest`).

This also adds a `__version__` attribute to the package itself, which is fairly standard (although unfortunately not ubiquitious). By adding a bit of [logic](https://github.com/Erotemic/ubelt/blob/main/setup.py#L18) to setup.py you can also make it such that `__version__` is the one source of truth for the version number, so it doesn't have to be changed in two places, but I didn't include that in this PR. 